### PR TITLE
Fix cURL error 60 when downloading zip file

### DIFF
--- a/src/Installation/DownloadBoilerplate.php
+++ b/src/Installation/DownloadBoilerplate.php
@@ -73,7 +73,7 @@ class DownloadBoilerplate
 	 */
 	protected function download($zipFile)
 	{
-		$response = (new Client)->get('https://github.com/rappasoft/laravel-5-boilerplate/archive/master.zip');
+		$response = (new Client(['verify' => false]))->get('https://github.com/rappasoft/laravel-5-boilerplate/archive/master.zip');
 		file_put_contents($zipFile, $response->getBody());
 		return $this;
 	}


### PR DESCRIPTION
I don't know why you did not experience this. It crashed on my first run.